### PR TITLE
Giving the readme some love, replace overloaded constructors with Builder

### DIFF
--- a/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentingInterceptor.java
+++ b/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentingInterceptor.java
@@ -31,13 +31,13 @@ public class InstrumentingInterceptor implements MethodInterceptor {
     
 
     private final MetricRegistry metricRegistry;
-    private final Optional<HealthCheckRegistry> healthCheckRegistry;
+    private final HealthCheckRegistry healthCheckRegistry;
     private final Predicate<Throwable> filter;
 
     @Inject
     public InstrumentingInterceptor(
             MetricRegistry metricRegistry,
-            Optional<HealthCheckRegistry> healthCheckRegistry,
+            HealthCheckRegistry healthCheckRegistry,
             Predicate<Throwable> filter
     ) {
         this.metricRegistry = metricRegistry;
@@ -62,7 +62,7 @@ public class InstrumentingInterceptor implements MethodInterceptor {
         }
 
         if (shouldRegisterHealthCheck(healthCheckRegistry, name, threshold)) {
-            registerHealthCheck(healthCheckRegistry.get(), name, threshold, errorMeter, timer);
+            registerHealthCheck(healthCheckRegistry, name, threshold, errorMeter, timer);
         }
 
         inFlight.inc();

--- a/instrumentor-core/src/main/java/com/sproutsocial/metrics/Instrumentation.java
+++ b/instrumentor-core/src/main/java/com/sproutsocial/metrics/Instrumentation.java
@@ -23,10 +23,10 @@ import com.sproutsocial.metrics.healthchecks.HealthChecks;
 
     private Instrumentation() {}
 
-    static <T> boolean shouldRegisterHealthCheck(Optional<HealthCheckRegistry> healthCheckRegistry, String name, Optional<T> ceiling) {
-        return healthCheckRegistry.isPresent() &&
+    static <T> boolean shouldRegisterHealthCheck(HealthCheckRegistry healthCheckRegistry, String name, Optional<T> ceiling) {
+        return healthCheckRegistry != null &&
                 ceiling.isPresent() &&
-                !healthCheckExists(healthCheckRegistry.get(), name);
+                !healthCheckExists(healthCheckRegistry, name);
     }
 
     static boolean healthCheckExists(HealthCheckRegistry healthCheckRegistry, String name) {


### PR DESCRIPTION
This one got a little big, but
- Add no-arg constructor for `Instrumentor`
- Add `Builder` for `Instrumentor`, remove a bunch of overloaded
  constructors
- Add a builder for `InstrumentedAnnotations`, removed a bunch of
  overloaded constructors
- Add no-arg constructor for `InstrumentedAnnotations`, which binds
  the created MetricRegistry and HealthCheckRegistry.
  - There is a possibility these bindings may clash with other bindings to
    either type of Registry. Might have to punt on this (and on the no-arg constructor)
  - other option is to bind these with a specific annotation. Maybe
    reuse `@Instrumented` as a `BindingAnnotation`?
- Don't let `HealthCheckRegistry` be an `Optional`. If clients
  don't want health checks, let them decide that at the `@Instrumented`
  of `Instrumentor` call site. Don't let that decision happen in two
  places.
- add a missing test, add an assertion to a test here or there
- Give the readme some love
  - new interfaces and no-arg constructors make examples shorter and
    simpler
  - move advice on `MetricRegistry.name()` higher up, explain that
    names are not magical
