### PR TITLE
update aop-version in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -338,7 +338,7 @@ You'll need to include the `instrumentor-aop` module:
 <dependency>
   <groupId>com.sproutsocial</groupId>
   <artifactId>instrumentor-aop</artifactId>
-  <version>1.0.0</version>
+  <version>0.7.5</version>
 </dependency>
 ```
 


### PR DESCRIPTION
I looked into ways to dynamically generating the readme and other documentation from the pom. Looks like there's a bit of up front work, but it could be worthwhile in the log run.