### PR TITLE
Support for instrumentation of classes

### DIFF
--- a/instrumentor-aop/pom.xml
+++ b/instrumentor-aop/pom.xml
@@ -3,20 +3,19 @@
     <parent>
         <artifactId>instrumentor</artifactId>
         <groupId>com.sproutsocial</groupId>
-        <version>0.7.5</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
-
-
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>instrumentor-aop</artifactId>
-    <version>0.7.5</version>
+    <version>0.8.0-SNAPSHOT</version>
+
     <dependencies>
         <dependency>
             <groupId>com.sproutsocial</groupId>
             <artifactId>instrumentor-core</artifactId>
-            <version>0.7.5</version>
+            <version>0.8.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentationDetails.java
+++ b/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentationDetails.java
@@ -1,0 +1,60 @@
+package com.sproutsocial.metrics;
+
+import com.google.common.base.Strings;
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.lang.reflect.Method;
+
+/**
+ * Created on 2/29/16.
+ */
+public interface InstrumentationDetails {
+
+    Instrumented getAnnotation(MethodInvocation methodInvocation);
+    String name(Method method, Instrumented annotation);
+
+    class ClassInstrumentation implements InstrumentationDetails {
+
+        @Override
+        public Instrumented getAnnotation(MethodInvocation methodInvocation) {
+            return methodInvocation
+                    .getMethod()
+                    .getDeclaringClass()
+                    .getAnnotation(Instrumented.class);
+        }
+
+        @Override
+        public String name(Method method, Instrumented annotation) {
+
+            String annotationName = annotation.name();
+
+            if (Strings.isNullOrEmpty(annotationName)) {
+                return Names.name(method);
+            } else {
+                return annotationName + method.getName();
+            }
+        }
+    }
+
+    class MethodInstrumentation implements InstrumentationDetails {
+
+        @Override
+        public Instrumented getAnnotation(MethodInvocation methodInvocation) {
+            return methodInvocation
+                    .getMethod()
+                    .getDeclaredAnnotation(Instrumented.class);
+        }
+
+        @Override
+        public String name(Method method, Instrumented annotation) {
+            String annotationName = annotation.name();
+
+            if (Strings.isNullOrEmpty(annotationName)) {
+                return Names.name(method);
+            } else {
+                return annotationName;
+            }
+        }
+    }
+
+}

--- a/instrumentor-aop/src/main/java/com/sproutsocial/metrics/Instrumented.java
+++ b/instrumentor-aop/src/main/java/com/sproutsocial/metrics/Instrumented.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * @author horthy
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Instrumented {
 
     String name() default "";

--- a/instrumentor-aop/src/test/java/com/sproutsocial/metrics/InstrumentingInterceptorTest.java
+++ b/instrumentor-aop/src/test/java/com/sproutsocial/metrics/InstrumentingInterceptorTest.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.Timer;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.Guice;
+import com.google.inject.Injector;
 
 /**
  * Created on 4/18/15
@@ -32,7 +33,8 @@ import com.google.inject.Guice;
 public class InstrumentingInterceptorTest {
 
 
-    public static final String NAME = "method";
+    public static final String NAME_METHOD = "method";
+    public static final String NAME_CLASS = "class";
     private @Mock Meter errorMeter;
     private @Mock Timer timer;
     private @Mock Counter counter;
@@ -41,11 +43,19 @@ public class InstrumentingInterceptorTest {
     private @Mock MetricRegistry metricRegistry;
     private @Mock HealthCheckRegistry healtchCheckRegistry;
 
-    private TestStub testStub;
+    private MethodTestStub methodTestStub;
+    private ClassAnnotatedTestStub classTestStub;
 
 
-    public static class TestStub {
-        @Instrumented(name = NAME, errorThreshold = 0.5d)
+    public static class MethodTestStub {
+        @Instrumented(name = NAME_METHOD, errorThreshold = 0.5d)
+        public void faultyMethod() {
+            throw new RuntimeException();
+        }
+    }
+
+    @Instrumented(name = NAME_CLASS, errorThreshold = 0.5d)
+    public static class ClassAnnotatedTestStub {
         public void faultyMethod() {
             throw new RuntimeException();
         }
@@ -59,23 +69,49 @@ public class InstrumentingInterceptorTest {
                         .healthCheckRegistry(healtchCheckRegistry)
                         .build();
 
-        testStub = Guice.createInjector(instrumentedAnnotations)
-                        .getInstance(TestStub.class);
+        Injector injector = Guice.createInjector(instrumentedAnnotations);
+
+        methodTestStub = injector.getInstance(MethodTestStub.class);
+        classTestStub = injector.getInstance(ClassAnnotatedTestStub.class);
     }
 
     @Test
     public void testTimerStopsOnceOnException() throws Exception {
-        when(metricRegistry.timer(NAME)).thenReturn(timer);
-        when(metricRegistry.meter(NAME + ".errors")).thenReturn(errorMeter);
-        when(metricRegistry.counter(NAME + ".inFlight")).thenReturn(counter);
+        when(metricRegistry.timer(NAME_METHOD)).thenReturn(timer);
+        when(metricRegistry.meter(NAME_METHOD + ".errors")).thenReturn(errorMeter);
+        when(metricRegistry.counter(NAME_METHOD + ".inFlight")).thenReturn(counter);
 
         when(timer.time()).thenReturn(context);
         
         try {
-            testStub.faultyMethod();
+            methodTestStub.faultyMethod();
         } catch (RuntimeException ignored) {}
 
-        verify(healtchCheckRegistry, times(1)).register(eq(NAME), any(HealthCheck.class));
+        verify(healtchCheckRegistry, times(1)).register(eq(NAME_METHOD), any(HealthCheck.class));
+
+        InOrder inOrder = inOrder(context, errorMeter, counter);
+        inOrder.verify(counter, times(1)).inc();
+        inOrder.verify(context, times(1)).close();
+        inOrder.verify(errorMeter, times(1)).mark();
+        inOrder.verify(counter, times(1)).dec();
+
+    }
+
+    @Test
+    public void testClassAnnotation() throws Exception {
+        String methodName = NAME_CLASS + "faultyMethod";
+
+        when(metricRegistry.timer(methodName)).thenReturn(timer);
+        when(metricRegistry.meter(methodName + ".errors")).thenReturn(errorMeter);
+        when(metricRegistry.counter(methodName + ".inFlight")).thenReturn(counter);
+
+        when(timer.time()).thenReturn(context);
+
+        try {
+            classTestStub.faultyMethod();
+        } catch (RuntimeException ignored) {}
+
+        verify(healtchCheckRegistry, times(1)).register(eq(methodName), any(HealthCheck.class));
 
         InOrder inOrder = inOrder(context, errorMeter, counter);
         inOrder.verify(counter, times(1)).inc();

--- a/instrumentor-core/pom.xml
+++ b/instrumentor-core/pom.xml
@@ -3,11 +3,13 @@
     <parent>
         <artifactId>instrumentor</artifactId>
         <groupId>com.sproutsocial</groupId>
-        <version>0.7.5</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>instrumentor-core</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/instrumentor-core/src/main/java/com/sproutsocial/metrics/ExceptionFilters.java
+++ b/instrumentor-core/src/main/java/com/sproutsocial/metrics/ExceptionFilters.java
@@ -1,0 +1,33 @@
+package com.sproutsocial.metrics;
+
+import java.util.function.Predicate;
+
+/**
+ * Created on 3/17/16.
+ */
+public final class ExceptionFilters {
+
+    private ExceptionFilters() {}
+
+    public static Predicate<Throwable> markAllExceptions() {
+        return new AnyThrowable();
+    }
+
+    public static Predicate<Throwable> markCheckedExceptions() {
+        return new CheckedExceptions();
+    }
+
+    private static class AnyThrowable implements Predicate<Throwable> {
+        @Override
+        public boolean test(Throwable throwable) {
+            return true;
+        }
+    }
+
+    private static class CheckedExceptions implements Predicate<Throwable> {
+        @Override
+        public boolean test(Throwable throwable) {
+            return throwable instanceof Exception && !(throwable instanceof RuntimeException);
+        }
+    }
+}

--- a/instrumentor-core/src/main/java/com/sproutsocial/metrics/Instrumentor.java
+++ b/instrumentor-core/src/main/java/com/sproutsocial/metrics/Instrumentor.java
@@ -45,7 +45,7 @@ public class Instrumentor {
     public static class Builder {
         private MetricRegistry metricRegistry = new MetricRegistry();
         private HealthCheckRegistry healthCheckRegistry = null;
-        private Predicate<Throwable> filter = any -> true;
+        private Predicate<Throwable> filter = ExceptionFilters.markAllExceptions();
 
         private Builder() {}
 

--- a/instrumentor-core/src/test/java/com/sproutsocial/metrics/ExceptionFiltersTest.java
+++ b/instrumentor-core/src/test/java/com/sproutsocial/metrics/ExceptionFiltersTest.java
@@ -1,0 +1,36 @@
+package com.sproutsocial.metrics;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+/**
+ * Created on 3/17/16.
+ */
+public class ExceptionFiltersTest {
+    @Test
+    public void testMarkAll() throws Exception {
+        assertTrue(ExceptionFilters.markAllExceptions().test(new Throwable()));
+        assertTrue(ExceptionFilters.markAllExceptions().test(new RuntimeException()));
+        assertTrue(ExceptionFilters.markAllExceptions().test(new NullPointerException()));
+        assertTrue(ExceptionFilters.markAllExceptions().test(new IllegalArgumentException()));
+
+        assertTrue(ExceptionFilters.markAllExceptions().test(new Exception()));
+        assertTrue(ExceptionFilters.markAllExceptions().test(new SQLException()));
+    }
+
+    @Test
+    public void testMarkChecked() throws Exception {
+        assertFalse(ExceptionFilters.markCheckedExceptions().test(new Throwable()));
+        assertFalse(ExceptionFilters.markCheckedExceptions().test(new RuntimeException()));
+        assertFalse(ExceptionFilters.markCheckedExceptions().test(new NullPointerException()));
+        assertFalse(ExceptionFilters.markCheckedExceptions().test(new IllegalArgumentException()));
+
+        assertTrue(ExceptionFilters.markCheckedExceptions().test(new Exception()));
+        assertTrue(ExceptionFilters.markCheckedExceptions().test(new SQLException()));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>instrumentor</artifactId>
-    <version>0.7.5</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Instrumentor</name>
     <description>Metrics toolkit for instrumentation</description>

--- a/readme.md
+++ b/readme.md
@@ -343,7 +343,8 @@ You'll need to include the `instrumentor-aop` module:
 ```
 
 You can use the `@Instrumented` annotation with the `InstrumentedAnnotations`
-guice module to specify methods that should be instrumented.
+guice module to specify methods that should be instrumented. You can add
+the `@Instrumented` annotation to a class to instrument all of its public methods.
 
 If you include an instance of the `InstrumentedAnnotations` module in your
 call to `Guice.createInjector()` (see below), then you can use the `@Instrumented`
@@ -371,7 +372,7 @@ class Example {
         
         MetricRegistry metricRegistry = injector.getInstance(MetricRegistry.class);
 
-        Timer timer = metricRegistry.getMeters().get("com.mycompany.Example.sayHello");
+        Timer timer = metricRegistry.getTimers().get("com.mycompany.Example.sayHello");
 
         assert timer.getOneMinuteRate() > 0;
         
@@ -413,7 +414,7 @@ class Example {
 
         MetricRegistry metricRegistry = injector.getInstance(MetricRegistry.class);
         
-        Timer timer = metricRegistry.getMeters().get("mySweetName");
+        Timer timer = metricRegistry.getTimers().get("mySweetName");
         
         assert timer.getOneMinuteRate() > 0;
         
@@ -491,7 +492,7 @@ class Example {
         example.sayHello();
         example.sayHello();
 
-        Timer timer = metricRegistry.getMeters().get("mySweetName");
+        Timer timer = metricRegistry.getTimers().get("mySweetName");
         
         assert timer.getOneMinuteRate() > 0;
         


### PR DESCRIPTION
`InstrumentedAnnotations` now binds an `InstrumentingInterceptor` to methods of a class annotated with `@Instrumented`.

##### `InstrumentationDetails`

Getting the `@Instrumented` for a single annotated method is different than getting it for all the public methods of a class, so:

- Refactor means of getting instance of `Instrumented` from
  `MethodInvocation` into `InstrumentationDetails` interface.
  I'm not all that tied to the name, open to suggestions.
- Refactor means of naming a single method into same
- Implemented by `MethodInstrumentation` (old behavior) and
  `ClassInstrumentation` (new behavior)
- I considered adding unit tests for this, but since we cant mock
  `Method` or `Class`, there's not much else we can test outside
  of what is already tested in `InstrumentingInterceptorTest`

To make use of the class-level interception we bind an additional interceptor,
at the same time allowing `@Instrumented` attributes on a method
to take precedence over `@Instrumented` on a class.

Also
----

- Clean up instances of `getMeters` in readme that should have been `getTimers`