### PR TITLE
Make some methods public, small cleanup stuff

### DIFF
--- a/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentationDetails.java
+++ b/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentationDetails.java
@@ -1,5 +1,6 @@
 package com.sproutsocial.metrics;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -31,7 +32,7 @@ public interface InstrumentationDetails {
             if (Strings.isNullOrEmpty(annotationName)) {
                 return Names.name(method);
             } else {
-                return annotationName + method.getName();
+                return MetricRegistry.name(annotationName, method.getName());
             }
         }
     }

--- a/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentingInterceptor.java
+++ b/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentingInterceptor.java
@@ -16,7 +16,7 @@ public class InstrumentingInterceptor implements MethodInterceptor {
     private final Instrumentor instrumentor;
     private final InstrumentationDetails instrumentationDetails;
 
-    private InstrumentingInterceptor(
+    public InstrumentingInterceptor(
             Instrumentor instrumentor,
             InstrumentationDetails instrumentationDetails
     ) {

--- a/instrumentor-aop/src/test/java/com/sproutsocial/metrics/InstrumentingInterceptorTest.java
+++ b/instrumentor-aop/src/test/java/com/sproutsocial/metrics/InstrumentingInterceptorTest.java
@@ -24,6 +24,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
+
 /**
  * Created on 4/18/15
  *
@@ -43,11 +44,11 @@ public class InstrumentingInterceptorTest {
     private @Mock MetricRegistry metricRegistry;
     private @Mock HealthCheckRegistry healtchCheckRegistry;
 
-    private MethodTestStub methodTestStub;
+    private MethodAnnotatedTestStub methodTestStub;
     private ClassAnnotatedTestStub classTestStub;
 
 
-    public static class MethodTestStub {
+    public static class MethodAnnotatedTestStub {
         @Instrumented(name = NAME_METHOD, errorThreshold = 0.5d)
         public void faultyMethod() {
             throw new RuntimeException();
@@ -71,7 +72,7 @@ public class InstrumentingInterceptorTest {
 
         Injector injector = Guice.createInjector(instrumentedAnnotations);
 
-        methodTestStub = injector.getInstance(MethodTestStub.class);
+        methodTestStub = injector.getInstance(MethodAnnotatedTestStub.class);
         classTestStub = injector.getInstance(ClassAnnotatedTestStub.class);
     }
 
@@ -99,7 +100,7 @@ public class InstrumentingInterceptorTest {
 
     @Test
     public void testClassAnnotation() throws Exception {
-        String methodName = NAME_CLASS + "faultyMethod";
+        String methodName = NAME_CLASS + ".faultyMethod";
 
         when(metricRegistry.timer(methodName)).thenReturn(timer);
         when(metricRegistry.meter(methodName + ".errors")).thenReturn(errorMeter);


### PR DESCRIPTION
- Make `InstrumentingInterceptor(Instrumentor, InstrumentationDetails)`
  public, I've found there are cases where this is handy. Playing with
  some `InstrumentationDetails` Impls that may let us bind a single
  `MethodInterceptor` -- the strategy can check the method and then the class for an `@Instrumented`     annotation
- Fix a bug where class-annotated methods were being named as
  `ClassNamemethodName` instead of `ClassName.methodName`