### PR TITLE
SYN-480: @Instrumented Class Throws NullPointerException When Implementing Non-@Instrumented Interface With Default Implementation 

### DIFF
--- a/instrumentor-aop/pom.xml
+++ b/instrumentor-aop/pom.xml
@@ -3,19 +3,18 @@
     <parent>
         <artifactId>instrumentor</artifactId>
         <groupId>com.sproutsocial</groupId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>instrumentor-aop</artifactId>
-    <version>1.1.0</version>
 
     <dependencies>
         <dependency>
             <groupId>com.sproutsocial</groupId>
             <artifactId>instrumentor-core</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentationDetails.java
+++ b/instrumentor-aop/src/main/java/com/sproutsocial/metrics/InstrumentationDetails.java
@@ -2,7 +2,6 @@ package com.sproutsocial.metrics;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;
-import org.aopalliance.intercept.MethodInvocation;
 
 import java.lang.reflect.Method;
 
@@ -11,17 +10,14 @@ import java.lang.reflect.Method;
  */
 public interface InstrumentationDetails {
 
-    Instrumented getAnnotation(MethodInvocation methodInvocation);
+    Instrumented getAnnotation(Method method);
     String name(Method method, Instrumented annotation);
 
     class ClassInstrumentation implements InstrumentationDetails {
 
         @Override
-        public Instrumented getAnnotation(MethodInvocation methodInvocation) {
-            return methodInvocation
-                    .getMethod()
-                    .getDeclaringClass()
-                    .getAnnotation(Instrumented.class);
+        public Instrumented getAnnotation(Method method) {
+            return method.getDeclaringClass().getAnnotation(Instrumented.class);
         }
 
         @Override
@@ -31,19 +27,16 @@ public interface InstrumentationDetails {
 
             if (Strings.isNullOrEmpty(annotationName)) {
                 return Names.name(method);
-            } else {
-                return MetricRegistry.name(annotationName, method.getName());
             }
+            return MetricRegistry.name(annotationName, method.getName());
         }
     }
 
     class MethodInstrumentation implements InstrumentationDetails {
 
         @Override
-        public Instrumented getAnnotation(MethodInvocation methodInvocation) {
-            return methodInvocation
-                    .getMethod()
-                    .getDeclaredAnnotation(Instrumented.class);
+        public Instrumented getAnnotation(Method method) {
+            return method.getDeclaredAnnotation(Instrumented.class);
         }
 
         @Override
@@ -52,9 +45,8 @@ public interface InstrumentationDetails {
 
             if (Strings.isNullOrEmpty(annotationName)) {
                 return Names.name(method);
-            } else {
-                return annotationName;
             }
+            return annotationName;
         }
     }
 

--- a/instrumentor-aop/src/test/java/com/sproutsocial/metrics/InstrumentingInterceptorTest.java
+++ b/instrumentor-aop/src/test/java/com/sproutsocial/metrics/InstrumentingInterceptorTest.java
@@ -1,12 +1,13 @@
 package com.sproutsocial.metrics;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +25,6 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
-
 /**
  * Created on 4/18/15
  *
@@ -36,13 +36,14 @@ public class InstrumentingInterceptorTest {
 
     public static final String NAME_METHOD = "method";
     public static final String NAME_CLASS = "class";
+    public static final String ANOTHER_NAME_CLASS = "anotherclass";
     private @Mock Meter errorMeter;
     private @Mock Timer timer;
     private @Mock Counter counter;
     private @Mock Timer.Context context;
 
     private @Mock MetricRegistry metricRegistry;
-    private @Mock HealthCheckRegistry healtchCheckRegistry;
+    private @Mock HealthCheckRegistry healthCheckRegistry;
 
     private MethodAnnotatedTestStub methodTestStub;
     private ClassAnnotatedTestStub classTestStub;
@@ -55,8 +56,22 @@ public class InstrumentingInterceptorTest {
         }
     }
 
+    public static interface NonAnnotatedInterfaceWithDefaultMethod {
+        default String successfulMethod() {
+            return "arbitrary data to verify method ran";
+        }
+    }
+
+    @Instrumented(name = ANOTHER_NAME_CLASS, errorThreshold = 0.5d)
+    public static interface AnnotatedInterfaceWithDefaultMethod {
+        default void anotherFaultyMethod() {
+          throw new RuntimeException();
+        }
+    }
+
     @Instrumented(name = NAME_CLASS, errorThreshold = 0.5d)
-    public static class ClassAnnotatedTestStub {
+    public static class ClassAnnotatedTestStub implements
+        NonAnnotatedInterfaceWithDefaultMethod, AnnotatedInterfaceWithDefaultMethod {
         public void faultyMethod() {
             throw new RuntimeException();
         }
@@ -67,7 +82,7 @@ public class InstrumentingInterceptorTest {
         final InstrumentedAnnotations instrumentedAnnotations =
                 InstrumentedAnnotations.builder()
                         .metricRegistry(metricRegistry)
-                        .healthCheckRegistry(healtchCheckRegistry)
+                        .healthCheckRegistry(healthCheckRegistry)
                         .build();
 
         Injector injector = Guice.createInjector(instrumentedAnnotations);
@@ -83,12 +98,12 @@ public class InstrumentingInterceptorTest {
         when(metricRegistry.counter(NAME_METHOD + ".inFlight")).thenReturn(counter);
 
         when(timer.time()).thenReturn(context);
-        
+
         try {
             methodTestStub.faultyMethod();
         } catch (RuntimeException ignored) {}
 
-        verify(healtchCheckRegistry, times(1)).register(eq(NAME_METHOD), any(HealthCheck.class));
+        verify(healthCheckRegistry, times(1)).register(eq(NAME_METHOD), any(HealthCheck.class));
 
         InOrder inOrder = inOrder(context, errorMeter, counter);
         inOrder.verify(counter, times(1)).inc();
@@ -112,7 +127,7 @@ public class InstrumentingInterceptorTest {
             classTestStub.faultyMethod();
         } catch (RuntimeException ignored) {}
 
-        verify(healtchCheckRegistry, times(1)).register(eq(methodName), any(HealthCheck.class));
+        verify(healthCheckRegistry, times(1)).register(eq(methodName), any(HealthCheck.class));
 
         InOrder inOrder = inOrder(context, errorMeter, counter);
         inOrder.verify(counter, times(1)).inc();
@@ -121,4 +136,44 @@ public class InstrumentingInterceptorTest {
         inOrder.verify(counter, times(1)).dec();
 
     }
+
+    @Test
+    public void testNonAnnotatedInterfaceDefaultMethod() {
+        assertEquals(
+            "arbitrary data to verify method ran",
+            classTestStub.successfulMethod()
+        );
+        verifyZeroInteractions(
+            context,
+            errorMeter,
+            counter,
+            timer,
+            healthCheckRegistry,
+            metricRegistry
+        );
+    }
+
+    @Test
+    public void testAnnotatedInterfaceDefaultMethod() throws Exception {
+        String methodName = ANOTHER_NAME_CLASS + ".anotherFaultyMethod";
+
+        when(metricRegistry.timer(methodName)).thenReturn(timer);
+        when(metricRegistry.meter(methodName + ".errors")).thenReturn(errorMeter);
+        when(metricRegistry.counter(methodName + ".inFlight")).thenReturn(counter);
+
+        when(timer.time()).thenReturn(context);
+
+        try {
+            classTestStub.anotherFaultyMethod();
+        } catch (RuntimeException ignored) {}
+
+        verify(healthCheckRegistry, times(1)).register(eq(methodName), any(HealthCheck.class));
+
+        InOrder inOrder = inOrder(context, errorMeter, counter);
+        inOrder.verify(counter, times(1)).inc();
+        inOrder.verify(context, times(1)).close();
+        inOrder.verify(errorMeter, times(1)).mark();
+        inOrder.verify(counter, times(1)).dec();
+    }
+
 }

--- a/instrumentor-core/pom.xml
+++ b/instrumentor-core/pom.xml
@@ -3,13 +3,12 @@
     <parent>
         <artifactId>instrumentor</artifactId>
         <groupId>com.sproutsocial</groupId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>instrumentor-core</artifactId>
-    <version>1.1.0</version>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial</groupId>
     <artifactId>instrumentor</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>pom</packaging>
     <name>Instrumentor</name>
     <description>Metrics toolkit for instrumentation</description>


### PR DESCRIPTION
I considered writing a [`Matcher<Method>`](https://google.github.io/guice/api-docs/4.1/javadoc/com/google/inject/matcher/Matcher.html) to filter out default methods, but I figured there would be circumstances where we would want to instrument those methods. This approach doesn't make any assumptions about the developer's intentions. Instead, it simply avoids the possibility of a `NullPointerException`.